### PR TITLE
Don't ignore lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ node_modules
 npm-debug.log
 
 # yarn
-yarn.lock
 yarn-error.log
 
 # misc
@@ -27,4 +26,3 @@ vendor
 temp
 tmp
 TODO.md
-package-lock.json


### PR DESCRIPTION
Lock files keep track of dependencies better than `package.json` and are supposed to be committed. NPM  [recommends](https://docs.npmjs.com/files/package-locks) that package-lock.json be committed.